### PR TITLE
Better error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ It currently only supports Socks4a, but support for Socks5 and plain Socks4 shou
 Example
 -------
     extern crate rustsocks;
-    
+
     use std::io::TcpStream;
     use rustsocks::socks4a::Socks4a;
-    
+
     fn main() {
       // Use the SOCKS proxy at 127.0.0.1 on port 9050
       let mut rs = Socks4a::new("127.0.0.1".to_string(), 9050);
-      
+
       // Connect through the socks proxy to example.com on port 80
       rs.connect("example.com", 80);
-      
+
       // Build the TcpStream and automatically set up the SOCKS proxy
-      let mut stream: TcpStream = rs.build();
-      
+      let mut stream: TcpStream = rs.build().unwrap();
+
       // Use stream like any other TcpStream.
     }

--- a/README.md
+++ b/README.md
@@ -17,10 +17,7 @@ Example
       let mut rs = Socks4a::new("127.0.0.1".to_string(), 9050);
 
       // Connect through the socks proxy to example.com on port 80
-      rs.connect("example.com", 80);
-
-      // Build the TcpStream and automatically set up the SOCKS proxy
-      let mut stream: TcpStream = rs.build().unwrap();
+      let mut stream = rs.connect("example.com", 80).unwrap();
 
       // Use stream like any other TcpStream.
     }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Example
 
     fn main() {
       // Use the SOCKS proxy at 127.0.0.1 on port 9050
-      let mut rs = Socks4a::new("127.0.0.1".to_string(), 9050);
+      let mut rs = Socks4a::new("127.0.0.1", 9050);
 
       // Connect through the socks proxy to example.com on port 80
       let mut stream = rs.connect("example.com", 80).unwrap();

--- a/src/socks4a.rs
+++ b/src/socks4a.rs
@@ -1,24 +1,18 @@
 use std::io::{IoResult, IoError, IoErrorKind, TcpStream, ConnectionRefused,
 							ConnectionFailed, OtherIoError};
 
-pub struct Socks4a {
-	sockshost: String,
-	socksport: u16,
-	host: String,
-	port: u16
+pub struct Socks4a<'a> {
+	socks_host: &'a str,
+	socks_port: u16,
 }
 
-impl Socks4a {
-	pub fn new(host: String, port: u16) -> Socks4a {
-		let tmphost = "";
-		let tmpport = 0;
-		Socks4a { sockshost: host, socksport: port, host: tmphost.to_string(),
-			port: tmpport }
+impl<'a> Socks4a<'a> {
+	pub fn new(host: &'a str, port: u16) -> Socks4a {
+		Socks4a { socks_host: host, socks_port: port }
 	}
 
 	pub fn connect(&mut self, host: &str, port: u16) -> IoResult<TcpStream> {
-		let mut stream = try!(TcpStream::connect(self.sockshost.as_slice(),
-																						 self.socksport));
+		let mut stream = try!(TcpStream::connect(self.socks_host, self.socks_port));
 		try!(stream.write([0x04, 0x01]));
 		try!(stream.write_be_u16(port));
 		try!(stream.write([0x00, 0x00, 0x00, 0x01]));

--- a/src/socks4a.rs
+++ b/src/socks4a.rs
@@ -12,21 +12,18 @@ impl Socks4a {
 	pub fn new(host: String, port: u16) -> Socks4a {
 		let tmphost = "";
 		let tmpport = 0;
-		Socks4a { sockshost: host, socksport: port, host: tmphost.to_string(), 
+		Socks4a { sockshost: host, socksport: port, host: tmphost.to_string(),
 			port: tmpport }
 	}
-	pub fn connect(&mut self, host: String, port: u16) {
-		self.host = host;
-		self.port = port;
-	}
-	pub fn build(&mut self) -> IoResult<TcpStream> {
+
+	pub fn connect(&mut self, host: &str, port: u16) -> IoResult<TcpStream> {
 		let mut stream = try!(TcpStream::connect(self.sockshost.as_slice(),
 																						 self.socksport));
 		try!(stream.write([0x04, 0x01]));
-		try!(stream.write_be_u16(self.port));
+		try!(stream.write_be_u16(port));
 		try!(stream.write([0x00, 0x00, 0x00, 0x01]));
 		try!(stream.write([0x00]));
-		try!(stream.write_str(self.host.as_slice()));
+		try!(stream.write_str(host));
 		try!(stream.write([0x00]));
 
 		// read null byte

--- a/src/socks4a.rs
+++ b/src/socks4a.rs
@@ -1,4 +1,5 @@
-use std::io::{IoResult, TcpStream};
+use std::io::{IoResult, IoError, IoErrorKind, TcpStream, ConnectionRefused,
+							ConnectionFailed, OtherIoError};
 
 pub struct Socks4a {
 	sockshost: String,
@@ -28,6 +29,33 @@ impl Socks4a {
 		try!(stream.write_str(self.host.as_slice()));
 		try!(stream.write([0x00]));
 
-		Ok(stream)
+		// read null byte
+		if 0 != try!(stream.read_u8()) {
+			return io_err(OtherIoError, "Expected null byte not found");
+		}
+
+		// read status
+		match try!(stream.read_u8()) {
+			// request granted
+			0x5a => {
+				let _port = try!(stream.read_be_u16());
+				let _ip = try!(stream.read_be_u32());
+
+				Ok(stream)
+			}
+			// request rejected or failed
+			0x5b => io_err(ConnectionRefused, "Request rejected or failed"),
+			// request failed because client is not running identd (or unreachable)
+			0x5c => io_err(ConnectionFailed, "Client unreachable"),
+			// request failed because client's identd could not confirm the user ID
+			// string in the request
+			0x5d => io_err(ConnectionRefused, "Unknown user"),
+			x => fail!("Unexpected status byte: {}", x)
+		}
 	}
 }
+
+fn io_err<T>(kind: IoErrorKind, desc: &'static str) -> IoResult<T> {
+	Err(IoError { kind: kind, desc: desc, detail: None })
+}
+

--- a/src/socks4a.rs
+++ b/src/socks4a.rs
@@ -1,4 +1,4 @@
-use std::io::TcpStream;
+use std::io::{IoResult, TcpStream};
 
 pub struct Socks4a {
 	sockshost: String,
@@ -18,15 +18,16 @@ impl Socks4a {
 		self.host = host;
 		self.port = port;
 	}
-	pub fn build(&mut self) -> TcpStream {
-		let mut stream = TcpStream::connect(self.sockshost.as_slice(), 
-			self.socksport).unwrap();
-		stream.write([0x04, 0x01]);
-		stream.write_be_u16(self.port);
-		stream.write([0x00, 0x00, 0x00, 0x01]);
-		stream.write([0x00]);
-		stream.write_str(self.host.as_slice());
-		stream.write([0x00]);
-		stream
+	pub fn build(&mut self) -> IoResult<TcpStream> {
+		let mut stream = try!(TcpStream::connect(self.sockshost.as_slice(),
+																						 self.socksport));
+		try!(stream.write([0x04, 0x01]));
+		try!(stream.write_be_u16(self.port));
+		try!(stream.write([0x00, 0x00, 0x00, 0x01]));
+		try!(stream.write([0x00]));
+		try!(stream.write_str(self.host.as_slice()));
+		try!(stream.write([0x00]));
+
+		Ok(stream)
 	}
 }

--- a/src/socks4a.rs
+++ b/src/socks4a.rs
@@ -1,52 +1,52 @@
 use std::io::{IoResult, IoError, IoErrorKind, TcpStream, ConnectionRefused,
-							ConnectionFailed, OtherIoError};
+              ConnectionFailed, OtherIoError};
 
 pub struct Socks4a<'a> {
-	socks_host: &'a str,
-	socks_port: u16,
+    socks_host: &'a str,
+    socks_port: u16,
 }
 
 impl<'a> Socks4a<'a> {
-	pub fn new(host: &'a str, port: u16) -> Socks4a {
-		Socks4a { socks_host: host, socks_port: port }
-	}
+    pub fn new(host: &'a str, port: u16) -> Socks4a {
+        Socks4a { socks_host: host, socks_port: port }
+    }
 
-	pub fn connect(&mut self, host: &str, port: u16) -> IoResult<TcpStream> {
-		let mut stream = try!(TcpStream::connect(self.socks_host, self.socks_port));
-		try!(stream.write([0x04, 0x01]));
-		try!(stream.write_be_u16(port));
-		try!(stream.write([0x00, 0x00, 0x00, 0x01]));
-		try!(stream.write([0x00]));
-		try!(stream.write_str(host));
-		try!(stream.write([0x00]));
+    pub fn connect(&mut self, host: &str, port: u16) -> IoResult<TcpStream> {
+        let mut stream = try!(TcpStream::connect(self.socks_host, self.socks_port));
+        try!(stream.write([0x04, 0x01]));
+        try!(stream.write_be_u16(port));
+        try!(stream.write([0x00, 0x00, 0x00, 0x01]));
+        try!(stream.write([0x00]));
+        try!(stream.write_str(host));
+        try!(stream.write([0x00]));
 
-		// read null byte
-		if 0 != try!(stream.read_u8()) {
-			return io_err(OtherIoError, "Expected null byte not found");
-		}
+        // read null byte
+        if 0 != try!(stream.read_u8()) {
+            return io_err(OtherIoError, "Expected null byte not found");
+        }
 
-		// read status
-		match try!(stream.read_u8()) {
-			// request granted
-			0x5a => {
-				let _port = try!(stream.read_be_u16());
-				let _ip = try!(stream.read_be_u32());
+        // read status
+        match try!(stream.read_u8()) {
+            // request granted
+            0x5a => {
+                let _port = try!(stream.read_be_u16());
+                let _ip = try!(stream.read_be_u32());
 
-				Ok(stream)
-			}
-			// request rejected or failed
-			0x5b => io_err(ConnectionRefused, "Request rejected or failed"),
-			// request failed because client is not running identd (or unreachable)
-			0x5c => io_err(ConnectionFailed, "Client unreachable"),
-			// request failed because client's identd could not confirm the user ID
-			// string in the request
-			0x5d => io_err(ConnectionRefused, "Unknown user"),
-			x => fail!("Unexpected status byte: {}", x)
-		}
-	}
+                Ok(stream)
+            }
+            // request rejected or failed
+            0x5b => io_err(ConnectionRefused, "Request rejected or failed"),
+            // request failed because client is not running identd (or unreachable)
+            0x5c => io_err(ConnectionFailed, "Client unreachable"),
+            // request failed because client's identd could not confirm the user ID
+            // string in the request
+            0x5d => io_err(ConnectionRefused, "Unknown user"),
+            x => fail!("Unexpected status byte: {}", x)
+        }
+    }
 }
 
 fn io_err<T>(kind: IoErrorKind, desc: &'static str) -> IoResult<T> {
-	Err(IoError { kind: kind, desc: desc, detail: None })
+    Err(IoError { kind: kind, desc: desc, detail: None })
 }
 


### PR DESCRIPTION
Also consume the stream for the first 8 bytes so clients can be oblivious to the SOCKS4a stream.
